### PR TITLE
Clarify press key input format

### DIFF
--- a/src/lib/mcp/tools/computer-action.ts
+++ b/src/lib/mcp/tools/computer-action.ts
@@ -64,7 +64,9 @@ const computerActionSchema = z.object({
     .object({
       keys: z
         .array(z.string())
-        .describe('X11 keysym names or combos like "Ctrl+t", "Return".'),
+        .describe(
+          'Each item must be one X11 keysym or chord, such as "Return", "Ctrl+t", or "Ctrl+minus". For sequential or repeated key presses, use separate array items; do not combine keys with spaces or commas. Use type_text to enter text.',
+        ),
       duration: z.number().int().min(0).optional(),
       hold_keys: z.array(z.string()).optional(),
     })


### PR DESCRIPTION
## Summary
- document that each `press_key.keys` item accepts one X11 keysym or chord
- show the canonical `Ctrl+minus` punctuation form
- direct agents to use separate array items for sequences and `type_text` for text

## Rollout
Merge after kernel/kernel-images#364 is deployed so the documented punctuation form is supported by the runtime.

## Testing
- `bunx prettier --check src/lib/mcp/tools/computer-action.ts`
- `bun test`
- `bun run build` compiled successfully and passed TypeScript checks, then stopped during page-data collection because required runtime configuration is unavailable locally

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a Zod `.describe()` string; no runtime validation or execution behavior is modified.
> 
> **Overview**
> Updates the **`computer_action`** MCP tool schema so the `press_key.keys` field description is explicit for agents calling the API.
> 
> The new text states that **each array element** is a single X11 keysym or chord (with examples including **`Ctrl+minus`**), that **sequences or repeats** belong in **separate array items** (not space- or comma-separated strings), and that **literal text** should use **`type_text`** instead of `press_key`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6e312d8fa4327d2fdc940b60751ece0cdd2de68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->